### PR TITLE
feat: secure edge email function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 # Resend Configuration (server-side)
 RESEND_API_KEY=your_resend_api_key_here
 
+# Edge Function Security
+VITE_EDGE_FUNCTION_KEY=your_edge_function_key_here
+EDGE_FUNCTION_KEY=your_edge_function_key_here
+

--- a/src/services/registrationService.ts
+++ b/src/services/registrationService.ts
@@ -41,7 +41,7 @@ export async function submitRegistration(data: RegistrationData) {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`
+            'x-function-key': import.meta.env.VITE_EDGE_FUNCTION_KEY
           },
           body: JSON.stringify({
             name: data.name,

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -4,7 +4,7 @@ import { Resend } from "npm:resend";
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization",
+  "Access-Control-Allow-Headers": "Content-Type, X-Function-Key",
 };
 
 interface EmailRequest {
@@ -23,6 +23,18 @@ serve(async (req: Request): Promise<Response> => {
       JSON.stringify({ error: "Method not allowed" }),
       {
         status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const functionKey = req.headers.get("x-function-key");
+  const validKey = Deno.env.get("EDGE_FUNCTION_KEY");
+  if (!functionKey || !validKey || functionKey !== validKey) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      {
+        status: 401,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       },
     );


### PR DESCRIPTION
## Summary
- remove Authorization header when calling edge function and use function key instead
- validate calls to send-email edge function against `EDGE_FUNCTION_KEY`
- document edge function key environment variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5b2b67b20832f9759cf500e70a337