### PR TITLE
chore: update react hooks plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,7 @@
+import hooks from 'eslint-plugin-react-hooks';
+
 export default [
+  hooks.configs.recommended,
   {
     ignores: ["dist"],
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.34.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "@typescript-eslint/parser": "^7.13.0",
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "prettier": "^3.3.2",


### PR DESCRIPTION
## Summary
- bump eslint-plugin-react-hooks to ^5.0.0
- add react-hooks recommended config to ESLint

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm install --no-audit` *(fails: 403 403 Forbidden - GET https://registry.npmjs.org/@typescript-eslint%2feslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c3d6c064832f9a1889434fdd1d88